### PR TITLE
rewrite setup.sh and uninstall.sh for fresh Raspberry Pi units

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,25 +1,117 @@
 #!/bin/bash
-sudo apt-get update -y
-sudo apt-get install -y --ignore-missing git tmux bluez bluez-tools bluez-firmware
-sudo apt-get install -y --ignore-missing python3 python3-dev python3-pip python3-dbus python3-pyudev python3-evdev python3-gi
+set -e
 
-sudo apt-get install -y libbluetooth-dev
-sudo PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install git+https://github.com/pybluez/pybluez.git#egg=pybluez
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BT_SERVICE="/lib/systemd/system/bluetooth.service"
+BT_CONF="/etc/bluetooth/main.conf"
+DBUS_CONF="/etc/dbus-1/system.d/org.thanhle.btkbservice.conf"
 
-sudo cp dbus/org.thanhle.btkbservice.conf /etc/dbus-1/system.d
-sudo systemctl restart dbus.service
+# --- Checks ---
 
-sudo sed -i '/^ExecStart=/ s/--noplugin=[^ ]*//' /lib/systemd/system/bluetooth.service
-sudo sed -i '/^ExecStart=/ s/$/ --noplugin=input/' /lib/systemd/system/bluetooth.service
-
-# Disable audio profile advertisement so hosts don't see device as audio sink.
-# Plugins remain loaded and can be re-enabled by removing these lines.
-sudo mkdir -p /etc/bluetooth
-if ! grep -q "^\[General\]" /etc/bluetooth/main.conf 2>/dev/null; then
-	echo "[General]" | sudo tee -a /etc/bluetooth/main.conf > /dev/null
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: must run as root (use sudo ./setup.sh)"
+    exit 1
 fi
-sudo sed -i '/^Disable\s*=/d' /etc/bluetooth/main.conf
-sudo sed -i '/^\[General\]/a Disable=Source,Sink,Media' /etc/bluetooth/main.conf
 
-sudo systemctl daemon-reload
-sudo systemctl restart bluetooth.service
+if ! grep -qi "raspberry\|bcm2" /proc/cpuinfo 2>/dev/null && [ ! -f /sys/firmware/devicetree/base/model ]; then
+    echo "Warning: this doesn't look like a Raspberry Pi. Continuing anyway..."
+fi
+
+echo "==> Updating package list..."
+apt-get update -y
+
+# --- System dependencies ---
+
+echo "==> Installing system packages..."
+apt-get install -y --no-install-recommends \
+    git \
+    tmux \
+    bluez \
+    bluez-tools \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-dbus \
+    python3-pyudev \
+    python3-evdev \
+    python3-gi \
+    libbluetooth-dev
+
+# pybluez (needed for Bluetooth socket support in Python)
+echo "==> Installing pybluez..."
+PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install git+https://github.com/pybluez/pybluez.git#egg=pybluez
+
+# --- D-Bus configuration ---
+
+echo "==> Installing D-Bus policy..."
+cp "$SCRIPT_DIR/dbus/org.thanhle.btkbservice.conf" "$DBUS_CONF"
+systemctl restart dbus.service
+
+# --- Bluetooth service configuration ---
+
+echo "==> Configuring Bluetooth service..."
+
+# Back up original bluetooth.service for uninstall
+if [ ! -f "$SCRIPT_DIR/bluetooth.service.bk" ]; then
+    cp "$BT_SERVICE" "$SCRIPT_DIR/bluetooth.service.bk"
+fi
+
+# Remove any existing --noplugin flag, then add ours
+# Disable 'input' plugin so BlueZ doesn't grab HID devices before we do
+sed -i '/^ExecStart=/ s/ --noplugin=[^ ]*//' "$BT_SERVICE"
+sed -i '/^ExecStart=/ s/$/ --noplugin=input/' "$BT_SERVICE"
+
+# --- BlueZ main.conf ---
+
+echo "==> Configuring BlueZ main.conf..."
+mkdir -p /etc/bluetooth
+
+# Create main.conf if it doesn't exist
+if [ ! -f "$BT_CONF" ]; then
+    cat > "$BT_CONF" << 'CONF'
+[General]
+CONF
+fi
+
+# Ensure [General] section exists
+if ! grep -q '^\[General\]' "$BT_CONF"; then
+    echo "[General]" >> "$BT_CONF"
+fi
+
+# Disable audio profiles so host doesn't see device as audio sink
+sed -i '/^Disable\s*=/d' "$BT_CONF"
+sed -i '/^\[General\]/a Disable=Source,Sink,Media' "$BT_CONF"
+
+# Set device class to combo keyboard+pointing peripheral
+sed -i '/^Class\s*=/d' "$BT_CONF"
+sed -i '/^\[General\]/a Class=0x0025C0' "$BT_CONF"
+
+# Make device discoverable and pairable by default
+sed -i '/^DiscoverableTimeout\s*=/d' "$BT_CONF"
+sed -i '/^\[General\]/a DiscoverableTimeout=0' "$BT_CONF"
+
+# --- Enable and restart services ---
+
+echo "==> Enabling bluetooth service on boot..."
+systemctl daemon-reload
+systemctl enable bluetooth.service
+systemctl restart bluetooth.service
+
+# Wait for adapter to come up
+sleep 2
+
+# Make adapter discoverable and pairable
+if command -v bluetoothctl &>/dev/null; then
+    echo "==> Setting adapter discoverable and pairable..."
+    bluetoothctl discoverable on 2>/dev/null || true
+    bluetoothctl pairable on 2>/dev/null || true
+fi
+
+echo ""
+echo "==> Setup complete!"
+echo ""
+echo "Next steps:"
+echo "  1. Edit server/btk_server.py and set TARGET_ADDRESS to your host's MAC"
+echo "  2. Pair the Pi with your host device via 'bluetoothctl'"
+echo "  3. Run: sudo ./boot.sh"
+echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,7 +1,38 @@
 #!/bin/bash
+set -e
 
-if [ -f "bluetooth.service.bk" ] ; then
-    sudo cp  bluetooth.service.bk /lib/systemd/system/bluetooth.service
-    sudo systemctl daemon-reload
-    sudo /etc/init.d/bluetooth start
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BT_SERVICE="/lib/systemd/system/bluetooth.service"
+BT_CONF="/etc/bluetooth/main.conf"
+DBUS_CONF="/etc/dbus-1/system.d/org.thanhle.btkbservice.conf"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: must run as root (use sudo ./uninstall.sh)"
+    exit 1
 fi
+
+echo "==> Restoring bluetooth service..."
+if [ -f "$SCRIPT_DIR/bluetooth.service.bk" ]; then
+    cp "$SCRIPT_DIR/bluetooth.service.bk" "$BT_SERVICE"
+    rm "$SCRIPT_DIR/bluetooth.service.bk"
+else
+    echo "    No backup found, removing --noplugin flag manually..."
+    sed -i '/^ExecStart=/ s/ --noplugin=[^ ]*//' "$BT_SERVICE"
+fi
+
+echo "==> Removing BlueZ config changes..."
+if [ -f "$BT_CONF" ]; then
+    sed -i '/^Disable=Source,Sink,Media/d' "$BT_CONF"
+    sed -i '/^Class=0x0025C0/d' "$BT_CONF"
+    sed -i '/^DiscoverableTimeout=0/d' "$BT_CONF"
+fi
+
+echo "==> Removing D-Bus policy..."
+rm -f "$DBUS_CONF"
+
+echo "==> Restarting services..."
+systemctl daemon-reload
+systemctl restart dbus.service
+systemctl restart bluetooth.service
+
+echo "==> Uninstall complete."


### PR DESCRIPTION
setup.sh now:
- Requires root, warns if not on a Pi
- Uses set -e for fail-fast
- Backs up bluetooth.service before modifying (for clean uninstall)
- Sets device class 0x0025C0 in main.conf (persistent across reboots)
- Sets DiscoverableTimeout=0 so device stays visible
- Enables bluetooth.service on boot
- Runs bluetoothctl to set discoverable/pairable
- Prints next-steps instructions
- Uses --no-install-recommends to keep install minimal
- Idempotent (safe to run multiple times)

uninstall.sh now:
- Restores bluetooth.service from backup
- Removes all main.conf additions
- Removes D-Bus policy file
- Restarts all affected services